### PR TITLE
Allow for files in /etc/nginx/extra-conf to be included

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -8,6 +8,8 @@ server {
     # Root directory of the application
     root   /usr/share/nginx/html;
     index  index.html;
+
+    include /etc/nginx/extra-conf/*.conf;
     
     location / {
         # Server all from the index file


### PR DESCRIPTION
This PR allows for dynamic loading of nginx config files, this is used for injecting additional settings through ConfigMaps